### PR TITLE
chore: Update NuGet packages and adopt Central Package Management

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
 
     <!-- Version - Single source of truth for synchronized releases -->
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
 
     <!-- Build configuration -->
     <LangVersion>latest</LangVersion>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,26 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Core dependencies -->
+    <PackageVersion Include="Cronos" Version="0.11.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="NodaTime" Version="3.3.1" />
+
+    <!-- Integration dependencies -->
+    <PackageVersion Include="Hangfire.Core" Version="1.8.23" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+<PackageVersion Include="Quartz" Version="3.16.1" />
+
+    <!-- Test dependencies -->
+    <PackageVersion Include="coverlet.collector" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="NodaTime.Testing" Version="3.3.1" />
+    <PackageVersion Include="NUnit" Version="4.5.1" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
+  </ItemGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,23 +4,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Core dependencies -->
-    <PackageVersion Include="Cronos" Version="0.11.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="NodaTime" Version="3.3.1" />
-
-    <!-- Integration dependencies -->
-    <PackageVersion Include="Hangfire.Core" Version="1.8.23" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-<PackageVersion Include="Quartz" Version="3.16.1" />
-
-    <!-- Test dependencies -->
     <PackageVersion Include="coverlet.collector" Version="8.0.0" />
+    <PackageVersion Include="Cronos" Version="0.11.1" />
+    <PackageVersion Include="Hangfire.Core" Version="1.8.23" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="NodaTime" Version="3.3.1" />
     <PackageVersion Include="NodaTime.Testing" Version="3.3.1" />
     <PackageVersion Include="NUnit" Version="4.5.1" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageVersion Include="Quartz" Version="3.16.1" />
   </ItemGroup>
 </Project>

--- a/src/HumanCron.Hangfire/HumanCron.Hangfire.csproj
+++ b/src/HumanCron.Hangfire/HumanCron.Hangfire.csproj
@@ -22,12 +22,12 @@
     <!-- Reference HumanCron.NCrontab for NCrontab conversion -->
     <ProjectReference Include="..\HumanCron.NCrontab\HumanCron.NCrontab.csproj" PrivateAssets="All" />
     <!-- Package references for consumers -->
-    <PackageReference Include="HumanCron" Version="[$(Version)]" />
-    <PackageReference Include="HumanCron.NCrontab" Version="[$(Version)]" />
+    <PackageReference Include="HumanCron" VersionOverride="[$(Version)]" />
+    <PackageReference Include="HumanCron.NCrontab" VersionOverride="[$(Version)]" />
     <!-- Hangfire core library -->
-    <PackageReference Include="Hangfire.Core" Version="1.8.22" />
-    <!-- Override vulnerable Newtonsoft.Json transitive dependency from Hangfire -->
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Hangfire.Core" />
+    <!-- Hangfire.Core still depends on Newtonsoft.Json >= 11.0.1 which has GHSA-5crp-9r3c-p9vr; pin to 13.0.4+ until Hangfire bumps their minimum -->
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/HumanCron.NCrontab/HumanCron.NCrontab.csproj
+++ b/src/HumanCron.NCrontab/HumanCron.NCrontab.csproj
@@ -20,19 +20,19 @@
 
   <ItemGroup>
     <!-- Reference core HumanCron library -->
-    <PackageReference Include="NodaTime" Version="3.2.3" />
+    <PackageReference Include="NodaTime" />
 
     <!-- HumanCron dependency with EXACT version match for synchronized releases -->
     <!-- Use ProjectReference for local development, PackageReference with exact version for NuGet -->
     <ProjectReference Include="..\HumanCron\HumanCron.csproj" PrivateAssets="All" />
-    <PackageReference Include="HumanCron" Version="[$(Version)]" />
+    <PackageReference Include="HumanCron" VersionOverride="[$(Version)]" />
     <!-- Brackets [x.y.z] mean "exactly this version only" in NuGet version ranges -->
 
     <!-- Cronos for NCrontab parsing (6-field support) -->
-    <PackageReference Include="Cronos" Version="0.11.1" />
+    <PackageReference Include="Cronos" />
 
     <!-- DI abstractions for extension registration -->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/HumanCron.Quartz/HumanCron.Quartz.csproj
+++ b/src/HumanCron.Quartz/HumanCron.Quartz.csproj
@@ -18,19 +18,19 @@
 
   <ItemGroup>
     <!-- Reference core HumanCron library -->
-    <PackageReference Include="NodaTime" Version="3.2.3" />
+    <PackageReference Include="NodaTime" />
 
     <!-- HumanCron dependency with EXACT version match for synchronized releases -->
     <!-- Use ProjectReference for local development, PackageReference with exact version for NuGet -->
     <ProjectReference Include="..\HumanCron\HumanCron.csproj" PrivateAssets="All" />
-    <PackageReference Include="HumanCron" Version="[$(Version)]" />
+    <PackageReference Include="HumanCron" VersionOverride="[$(Version)]" />
     <!-- Brackets [x.y.z] mean "exactly this version only" in NuGet version ranges -->
 
     <!-- Quartz.NET dependency -->
-    <PackageReference Include="Quartz" Version="3.15.1" />
+    <PackageReference Include="Quartz" />
 
     <!-- DI abstractions for extension registration -->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/HumanCron/HumanCron.csproj
+++ b/src/HumanCron/HumanCron.csproj
@@ -23,9 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cronos" Version="0.11.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
-    <PackageReference Include="NodaTime" Version="3.2.3" />
+    <PackageReference Include="Cronos" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="NodaTime" />
   </ItemGroup>
 
 </Project>

--- a/tests/HumanCron.Tests/HumanCron.Tests.csproj
+++ b/tests/HumanCron.Tests/HumanCron.Tests.csproj
@@ -10,17 +10,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NodaTime.Testing" Version="3.2.3" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NodaTime.Testing" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="6.0.0" />
-    <PackageReference Include="Quartz" Version="3.15.1" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Quartz" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Adopt **Central Package Management** via `Directory.Packages.props` — all package versions now managed in a single file
- Update all 13 NuGet packages to their latest versions
- Self-referencing packages (`HumanCron`, `HumanCron.NCrontab`) use `VersionOverride` for their dynamic `[$(Version)]` expressions

### Updated packages
| Package | From | To |
|---|---|---|
| NodaTime | 3.2.3 | 3.3.1 |
| Microsoft.Extensions.DI(.Abstractions) | 10.0.1 | 10.0.5 |
| Quartz | 3.15.1 | 3.16.1 |
| Hangfire.Core | 1.8.22 | 1.8.23 |
| coverlet.collector | 6.0.4 | 8.0.0 |
| Microsoft.NET.Test.Sdk | 18.0.1 | 18.3.0 |
| NUnit | 4.4.0 | 4.5.1 |
| NUnit.Analyzers | 4.11.2 | 4.12.0 |
| NUnit3TestAdapter | 6.0.0 | 6.1.0 |

> **Note:** `Newtonsoft.Json` 13.0.4 pin remains — Hangfire.Core 1.8.23 still depends on `>= 11.0.1` which has [GHSA-5crp-9r3c-p9vr](https://github.com/advisories/GHSA-5crp-9r3c-p9vr).

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 1011/1011 tests passing
- [x] `dotnet package list --outdated` — no remaining outdated packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)