### PR TITLE
chore(deps): April 2026 NuGet package updates + phantom dependency cleanup

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,15 +7,15 @@
     <PackageVersion Include="coverlet.collector" Version="8.0.0" />
     <PackageVersion Include="Cronos" Version="0.11.1" />
     <PackageVersion Include="Hangfire.Core" Version="1.8.23" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NodaTime" Version="3.3.1" />
     <PackageVersion Include="NodaTime.Testing" Version="3.3.1" />
     <PackageVersion Include="NUnit" Version="4.5.1" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="Quartz" Version="3.16.1" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,6 @@
     <PackageVersion Include="NUnit" Version="4.5.1" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageVersion Include="Quartz" Version="3.16.1" />
+    <PackageVersion Include="Quartz" Version="3.18.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,6 @@
 
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="8.0.0" />
-    <PackageVersion Include="Cronos" Version="0.11.1" />
     <PackageVersion Include="Hangfire.Core" Version="1.8.23" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="8.0.0" />
     <PackageVersion Include="Hangfire.Core" Version="1.8.23" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />

--- a/src/HumanCron.NCrontab/HumanCron.NCrontab.csproj
+++ b/src/HumanCron.NCrontab/HumanCron.NCrontab.csproj
@@ -28,9 +28,6 @@
     <PackageReference Include="HumanCron" VersionOverride="[$(Version)]" />
     <!-- Brackets [x.y.z] mean "exactly this version only" in NuGet version ranges -->
 
-    <!-- Cronos for NCrontab parsing (6-field support) -->
-    <PackageReference Include="Cronos" />
-
     <!-- DI abstractions for extension registration -->
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>

--- a/src/HumanCron/ARCHITECTURE.md
+++ b/src/HumanCron/ARCHITECTURE.md
@@ -478,40 +478,16 @@ public static class ServiceCollectionExtensions
 
 ---
 
-## NuGet Dependencies
+## Package Management
 
-> Versions are managed centrally via `Directory.Packages.props` (Central Package Management); per-project `<PackageReference>` entries omit `Version=`.
+This project uses **Central Package Management (CPM)**. All NuGet package versions are declared once in `Directory.Packages.props` at the repository root; individual `.csproj` files reference packages without `Version=` attributes.
 
-### HumanCron.csproj (Core)
+**Why:**
+- Single source of truth for versions across core, extensions, and tests
+- Synchronized version bumps via single-file edits
+- Prevents the class of bugs where two projects pull mismatched versions of the same transitive dependency
 
-```xml
-<ItemGroup>
-  <!-- DI abstractions (no concrete implementation) -->
-  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-</ItemGroup>
-```
-
-### HumanCron.Quartz.csproj (Extension)
-
-```xml
-<ItemGroup>
-  <!-- Reference core library -->
-  <ProjectReference Include="..\HumanCron\HumanCron.csproj" />
-
-  <!-- Quartz.NET dependency -->
-  <PackageReference Include="Quartz" />
-</ItemGroup>
-```
-
-### HumanCron.Tests.csproj
-
-```xml
-<ItemGroup>
-  <PackageReference Include="NUnit" />
-  <PackageReference Include="NUnit3TestAdapter" />
-  <PackageReference Include="Microsoft.NET.Test.Sdk" />
-</ItemGroup>
-```
+For the current dependency set of any project, see its `.csproj` file directly.
 
 ---
 

--- a/src/HumanCron/ARCHITECTURE.md
+++ b/src/HumanCron/ARCHITECTURE.md
@@ -480,12 +480,14 @@ public static class ServiceCollectionExtensions
 
 ## NuGet Dependencies
 
+> Versions are managed centrally via `Directory.Packages.props` (Central Package Management); per-project `<PackageReference>` entries omit `Version=`.
+
 ### HumanCron.csproj (Core)
 
 ```xml
 <ItemGroup>
   <!-- DI abstractions (no concrete implementation) -->
-  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
 </ItemGroup>
 ```
 
@@ -497,7 +499,7 @@ public static class ServiceCollectionExtensions
   <ProjectReference Include="..\HumanCron\HumanCron.csproj" />
 
   <!-- Quartz.NET dependency -->
-  <PackageReference Include="Quartz" Version="3.15.1" />
+  <PackageReference Include="Quartz" />
 </ItemGroup>
 ```
 
@@ -505,10 +507,9 @@ public static class ServiceCollectionExtensions
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="NUnit" Version="4.3.1" />
-  <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-  <PackageReference Include="FluentAssertions" Version="7.0.0" />
+  <PackageReference Include="NUnit" />
+  <PackageReference Include="NUnit3TestAdapter" />
+  <PackageReference Include="Microsoft.NET.Test.Sdk" />
 </ItemGroup>
 ```
 

--- a/src/HumanCron/ARCHITECTURE.md
+++ b/src/HumanCron/ARCHITECTURE.md
@@ -486,9 +486,6 @@ public static class ServiceCollectionExtensions
 <ItemGroup>
   <!-- DI abstractions (no concrete implementation) -->
   <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-
-  <!-- Cron validation and next-run calculation -->
-  <PackageReference Include="Cronos" Version="0.8.4" />
 </ItemGroup>
 ```
 
@@ -677,8 +674,6 @@ Used by both UnixCronBuilder and QuartzCronBuilder for DRY formatting.
 
 ## Related Documentation
 
-- [Original Research Document](/tmp/natural-language-scheduling-research.md)
-- [Cronos Library](https://www.nuget.org/packages/Cronos)
 - [Quartz.NET Documentation](https://www.quartz-scheduler.net/)
 
 ---

--- a/src/HumanCron/HumanCron.csproj
+++ b/src/HumanCron/HumanCron.csproj
@@ -23,7 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cronos" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="NodaTime" />
   </ItemGroup>

--- a/tests/HumanCron.Tests/HumanCron.Tests.csproj
+++ b/tests/HumanCron.Tests/HumanCron.Tests.csproj
@@ -10,7 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NodaTime.Testing" />


### PR DESCRIPTION
## Summary

Routine NuGet package update round, plus removal of two phantom dependencies (Cronos and coverlet.collector) that have been declared since the v0.1.0 release scaffold but were never actually invoked. Verified via `git log -S` across all branches and full grep of public API surfaces.

## Commits

1. **Low-risk patch and minor bumps**
   - `Microsoft.Extensions.DependencyInjection` 10.0.5 -> 10.0.6
   - `Microsoft.Extensions.DependencyInjection.Abstractions` 10.0.5 -> 10.0.6
   - `Microsoft.NET.Test.Sdk` 18.3.0 -> 18.4.0
   - `NUnit3TestAdapter` 6.1.0 -> 6.2.0
2. **Remove unused Cronos** + ARCHITECTURE.md doc cleanup (also drops the local-only `/tmp/` research-doc link)
3. **Quartz 3.16.1 -> 3.18.0** (~40 bug fixes in 3.17, 8 new features + perf in 3.18). Pre-flight grep confirmed zero usage of the newly-`[Obsolete]` `DirtyFlagMap` APIs, so `TreatWarningsAsErrors=true` is safe.
4. **Remove unused coverlet.collector** (CI runs `dotnet test` without `--collect`, no `.runsettings`, no codecov pipeline). Re-add is one line if coverage is ever wired up.

## Why remove the phantom dependencies?

Both Cronos and coverlet.collector were added by the initial v0.1.0 scaffold and have been carried unused ever since. `git log --all -S "Cronos" -- '*.cs'` returns zero commits across the project's entire history. Cronos's design (one-way cron-string -> next-fire calculation) doesn't fit HumanCron's bidirectional translation-layer model anyway. coverlet.collector without `--collect:"XPlat Code Coverage"` is fully inert — verified by tests still passing identically (1011/1011) after removal.

## Test plan

- [x] `dotnet restore` clean after each commit
- [x] `dotnet build` clean (0 warnings, `TreatWarningsAsErrors=true` enforced)
- [x] `dotnet test` — 1011 tests pass, 0 failures, after each of the four commits
- [x] No remaining `Cronos` references in `*.csproj`, `*.props`, `*.md`, or `*.cs` files
- [x] No remaining `coverlet` references in `*.csproj`, `*.props`, or workflow files
- [ ] CI build-and-test workflow passes on PR

## Out of scope (follow-up)

While auditing, surfaced 3 high-priority and 3 medium-priority test gaps (notably the Hangfire `Assert.Pass()` stub-only tests at `tests/HumanCron.Tests/Hangfire/HangfireExtensionsTests.cs:105-169`, which validate nothing about the Hangfire integration). Documented locally at `tmp/test-gap-findings.md` (gitignored) for a separate test-hardening PR after this one merges.

## Notes for review

- Per project convention: please **merge** rather than squash so the four-commit structure is preserved in `master`'s history.
